### PR TITLE
Add Spring Boot app exposing REST endpoint as MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# MCP Spring Boot Demo
+
+This repository contains a small Spring Boot project that exposes a normal REST
+endpoint and makes the same functionality available as a Model Context
+Protocol (MCP) tool over HTTP.
+
+## Architecture
+
+The demo application runs with Spring Boot's embedded Tomcat servlet
+container.  Standard REST controllers are mapped as usual using `@RestController`
+and `@GetMapping`.  The library module provides an `@McpTool` annotation and a
+minimal JSON-RPC controller that publishes these methods under a `/mcp`
+endpoint.
+
+When the application starts:
+
+1. Spring Boot creates the embedded Tomcat instance that serves HTTP requests.
+2. `McpToolRegistry` scans all `@RestController` beans for methods annotated
+   with `@McpTool` and registers them.
+3. `McpController` handles POST requests to `/mcp` and dispatches MCP
+   commands such as `list_tools` and `call_tool`.
+
+Both the REST endpoint and the MCP endpoint share the same Tomcat instance and
+application context, so they can call the same service methods.
+
+## Running the demo
+
+```bash
+mvn -pl mcp-spring-demo spring-boot:run
+```
+
+Once running, the following HTTP requests are available:
+
+* `GET /hello` – returns "Hello World"
+* `POST /mcp` – JSON-RPC endpoint.  Example body:
+
+```json
+{ "jsonrpc": "2.0", "id": 1, "method": "call_tool", "params": { "name": "hello" } }
+```
+
+## Pros and Cons
+
+**Pros**
+
+* Single deployment: REST and MCP tools live in the same Spring Boot/Tomcat
+  application.
+* Familiar programming model using Spring annotations.
+* Minimal boilerplate – only add `@McpTool` to expose an existing controller
+  method.
+
+**Cons**
+
+* Only supports HTTP transport; no stdio or WebSocket integration yet.
+* Tool discovery relies on scanning controllers at startup, which may add a
+  small overhead for large applications.
+* Error handling and authentication are minimal for demonstration purposes.
+
+## Testing
+
+Unit tests can be executed with:
+
+```bash
+mvn -q test
+```
+
+(The build currently requires internet access to download Spring Boot
+artifacts.)
+

--- a/mcp-spring-demo/pom.xml
+++ b/mcp-spring-demo/pom.xml
@@ -1,0 +1,39 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>mcp-spring-parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mcp-spring-demo</artifactId>
+  <name>mcp-spring-demo</name>
+  <description>Demo using the MCP Spring library</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>mcp-spring-lib</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/mcp-spring-demo/src/main/java/com/example/mcpdemo/HelloController.java
+++ b/mcp-spring-demo/src/main/java/com/example/mcpdemo/HelloController.java
@@ -1,0 +1,20 @@
+package com.example.mcpdemo;
+
+import com.example.mcp.McpTool;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+    private final HelloService service;
+
+    public HelloController(HelloService service) {
+        this.service = service;
+    }
+
+    @McpTool(value = "hello", description = "Returns a friendly greeting")
+    @GetMapping("/hello")
+    public String hello() {
+        return service.getGreeting();
+    }
+}

--- a/mcp-spring-demo/src/main/java/com/example/mcpdemo/HelloService.java
+++ b/mcp-spring-demo/src/main/java/com/example/mcpdemo/HelloService.java
@@ -1,0 +1,10 @@
+package com.example.mcpdemo;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class HelloService {
+    public String getGreeting() {
+        return "Hello World";
+    }
+}

--- a/mcp-spring-demo/src/main/java/com/example/mcpdemo/McpSpringApplication.java
+++ b/mcp-spring-demo/src/main/java/com/example/mcpdemo/McpSpringApplication.java
@@ -1,0 +1,11 @@
+package com.example.mcpdemo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class McpSpringApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(McpSpringApplication.class, args);
+    }
+}

--- a/mcp-spring-demo/src/test/java/com/example/mcpdemo/HelloControllerTest.java
+++ b/mcp-spring-demo/src/test/java/com/example/mcpdemo/HelloControllerTest.java
@@ -1,0 +1,44 @@
+package com.example.mcpdemo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class HelloControllerTest {
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void helloReturnsGreeting() {
+        String body = restTemplate.getForObject("/hello", String.class);
+        assertThat(body).isEqualTo("Hello World");
+    }
+
+    @Test
+    void mcpListsAndCallsTool() {
+        Map<String, Object> listReq = Map.of(
+            "jsonrpc", "2.0",
+            "id", 1,
+            "method", "list_tools"
+        );
+        Map listResp = restTemplate.postForObject("/mcp", listReq, Map.class);
+        List<Map<String, Object>> tools = (List<Map<String, Object>>) ((Map) listResp.get("result")).get("tools");
+        assertThat(tools).extracting("name").contains("hello");
+
+        Map<String, Object> callReq = Map.of(
+            "jsonrpc", "2.0",
+            "id", 2,
+            "method", "call_tool",
+            "params", Map.of("name", "hello")
+        );
+        Map callResp = restTemplate.postForObject("/mcp", callReq, Map.class);
+        List<Map<String, Object>> content = (List<Map<String, Object>>) ((Map) callResp.get("result")).get("content");
+        assertThat(content.get(0).get("text")).isEqualTo("Hello World");
+    }
+}

--- a/mcp-spring-lib/pom.xml
+++ b/mcp-spring-lib/pom.xml
@@ -1,0 +1,20 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>mcp-spring-parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mcp-spring-lib</artifactId>
+  <name>mcp-spring-lib</name>
+  <description>Library exposing annotated Spring REST controllers as MCP tools</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/mcp-spring-lib/src/main/java/com/example/mcp/McpAutoConfiguration.java
+++ b/mcp-spring-lib/src/main/java/com/example/mcp/McpAutoConfiguration.java
@@ -1,0 +1,12 @@
+package com.example.mcp;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Auto configuration that brings in the MCP components.
+ */
+@Configuration
+@ComponentScan("com.example.mcp")
+public class McpAutoConfiguration {
+}

--- a/mcp-spring-lib/src/main/java/com/example/mcp/McpController.java
+++ b/mcp-spring-lib/src/main/java/com/example/mcp/McpController.java
@@ -1,0 +1,50 @@
+package com.example.mcp;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Minimal HTTP-based MCP server controller.
+ */
+@RestController
+public class McpController {
+    private final McpToolRegistry registry;
+
+    public McpController(McpToolRegistry registry) {
+        this.registry = registry;
+    }
+
+    @PostMapping(path = "/mcp", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public Map<String, Object> handle(@RequestBody Map<String, Object> request) throws Exception {
+        String method = (String) request.get("method");
+        Object id = request.get("id");
+        Map<String, Object> result = new HashMap<>();
+
+        if ("list_tools".equals(method)) {
+            result.put("tools", registry.listTools());
+        } else if ("call_tool".equals(method)) {
+            Map<String, Object> params = (Map<String, Object>) request.get("params");
+            String name = params != null ? (String) params.get("name") : null;
+            Object output = registry.call(name);
+            if (output != null) {
+                Map<String, Object> content = Map.of("type", "text", "text", output.toString());
+                result.put("content", List.of(content));
+            } else {
+                result.put("error", "Unknown tool");
+            }
+        } else {
+            result.put("error", "Unknown method");
+        }
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("jsonrpc", "2.0");
+        response.put("id", id);
+        response.put("result", result);
+        return response;
+    }
+}

--- a/mcp-spring-lib/src/main/java/com/example/mcp/McpTool.java
+++ b/mcp-spring-lib/src/main/java/com/example/mcp/McpTool.java
@@ -1,0 +1,23 @@
+package com.example.mcp;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to expose a Spring MVC handler method as an MCP tool.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface McpTool {
+    /**
+     * Unique tool name.
+     */
+    String value();
+
+    /**
+     * Human friendly description.
+     */
+    String description() default "";
+}

--- a/mcp-spring-lib/src/main/java/com/example/mcp/McpToolRegistry.java
+++ b/mcp-spring-lib/src/main/java/com/example/mcp/McpToolRegistry.java
@@ -1,0 +1,75 @@
+package com.example.mcp;
+
+import jakarta.annotation.PostConstruct;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Registry that discovers and invokes MCP tools.
+ */
+@Component
+public class McpToolRegistry {
+    private final ApplicationContext context;
+    private final Map<String, ToolMethod> tools = new HashMap<>();
+
+    @Autowired
+    public McpToolRegistry(ApplicationContext context) {
+        this.context = context;
+    }
+
+    @PostConstruct
+    public void init() {
+        Map<String, Object> beans = context.getBeansWithAnnotation(RestController.class);
+        for (Object bean : beans.values()) {
+            Class<?> targetClass = AopUtils.getTargetClass(bean);
+            ReflectionUtils.doWithMethods(targetClass, method -> {
+                McpTool annotation = AnnotationUtils.findAnnotation(method, McpTool.class);
+                if (annotation != null) {
+                    tools.put(annotation.value(), new ToolMethod(bean, method, annotation));
+                }
+            });
+        }
+    }
+
+    public List<Map<String, Object>> listTools() {
+        List<Map<String, Object>> list = new ArrayList<>();
+        tools.forEach((name, tm) -> {
+            Map<String, Object> tool = new HashMap<>();
+            tool.put("name", name);
+            tool.put("description", tm.annotation.description());
+            tool.put("inputSchema", Map.of("type", "object", "properties", Map.of(), "required", List.of()));
+            list.add(tool);
+        });
+        return list;
+    }
+
+    public Object call(String name) throws Exception {
+        ToolMethod tm = tools.get(name);
+        if (tm == null) {
+            return null;
+        }
+        return tm.method.invoke(tm.bean);
+    }
+
+    private static class ToolMethod {
+        final Object bean;
+        final Method method;
+        final McpTool annotation;
+
+        ToolMethod(Object bean, Method method, McpTool annotation) {
+            this.bean = bean;
+            this.method = method;
+            this.annotation = annotation;
+        }
+    }
+}

--- a/mcp-spring-lib/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/mcp-spring-lib/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.example.mcp.McpAutoConfiguration

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,24 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.2.5</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>com.example</groupId>
+  <artifactId>mcp-spring-parent</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>mcp-spring-lib</module>
+    <module>mcp-spring-demo</module>
+  </modules>
+
+  <properties>
+    <java.version>17</java.version>
+  </properties>
+</project>


### PR DESCRIPTION
## Summary
- add Spring Boot demo project with a `/hello` REST API
- expose same greeting through an HTTP MCP endpoint
- document Tomcat hosting details, run instructions, and pros/cons

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.example:mcp-spring-parent:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_6893788b20f08329bd21b869b0e6bf56